### PR TITLE
Change pop timings to used Elapsed

### DIFF
--- a/popverb/transaction.go
+++ b/popverb/transaction.go
@@ -24,9 +24,11 @@ var Transaction = func(db *pop.Connection) echo.MiddlewareFunc {
 				}
 				ctx.Set("tx", tx)
 
+				before := tx.Elapsed
 				err := handler(ctx)
+				after := tx.Elapsed
 				if clg != nil {
-					logPopTimings(lg, tx.Timings)
+					logPopTimings(lg, []time.Duration{time.Duration(after - before)})
 				}
 				return err
 			})


### PR DESCRIPTION
Pop timings were changed to become an elapsed timer, so comparing
elapsed time before and after will yield the total amount of time spent
in Pop. This was done to make timing threadsafe.